### PR TITLE
[spike] allow functions to be stripped from imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,16 @@ module.exports = function(filteredImports) {
 function referencesFilteredImport(identifier, filteredImports) {
   for (var moduleName in filteredImports) {
     var imports = filteredImports[moduleName];
+
+    //NOTE: GJ: just spiking something, mind your head
     for (var i = 0; i < imports.length; i++) {
+      var methodName = imports[i]; //TODO: GJ: naming
+      if(methodName[0] === '.') {
+        if('.' + identifier.container.property.name === methodName) { //TODO : GJ: refactor
+          return true;
+        }
+      }
+
       if (identifier.referencesImport(moduleName, imports[i])) {
         return true;
       }

--- a/test/fixtures/ember-debug/expected.js
+++ b/test/fixtures/ember-debug/expected.js
@@ -1,0 +1,4 @@
+var _ember = require('ember');
+
+_ember['default'].isEmpty(); //this should remain
+_ember['default'].isEmpty(); //this should remain

--- a/test/fixtures/ember-debug/fixture.js
+++ b/test/fixtures/ember-debug/fixture.js
@@ -1,0 +1,11 @@
+import Em from 'ember';
+import Ember from 'ember';
+
+Em.assert('this will be stripped');
+Em.debug('this will also be stripped');
+
+Ember.assert('this will be stripped');
+Ember.debug('this also will be stripped');
+
+Em.isEmpty(); //this should remain
+Ember.isEmpty(); //this should remain

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ function testFixture(name, options) {
       plugins: [filterImports(options)]
     });
 
-    assert.strictEqual(result.code, expected);
+    assert.strictEqual(result.code.trim(), expected.trim());
   });
 }
 
@@ -31,4 +31,8 @@ describe('babel-plugin-filter-imports', function() {
   testFixture('partial-filter-1', { assert: ['default'], cloud: ['default'] });
   testFixture('partial-filter-2', { assert: ['a', 'c'] });
   testFixture('partial-filter-3', { assert: ['a', 'c'] });
+
+  //NOTE: GJ: this is just an experiment, the actual API changes may be different
+  //          this will strip `Ember.assert` and `Ember.debug` function calls
+  testFixture('ember-debug', { ember: ['.assert', '.debug'] });
 });


### PR DESCRIPTION
This is a spike for https://github.com/ember-cli/rfcs/pull/50.

With the following configuration (the API needs work):

``` js

filterImports({
  { ember: ['.assert', '.debug'] }
})
```

It transforms the following:

``` js
import Em from 'ember';

Em.assert('this will be stripped');
Em.debug('this will also be stripped');
Em.isEmpty([]); //true
```

In to:

``` js
import Em from 'ember';

Em.isEmpty([]); //true
```
